### PR TITLE
fix: pin letta-client version to <1.0.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ image = (
         "requests",
         "pydantic>=2.0",
         "telegramify-markdown",
-        "letta_client",
+        "letta_client<1.0.0",
         "cryptography>=3.4.8",
         "openai>=1.40.0",
         "python-multipart>=0.0.9",


### PR DESCRIPTION
Since letta-client v1+, we get this error: `Error handling login command: cannot access local variable 'ApiError' where it is not associated with a value`
We should update the code to make it compatible with the new SDK but in the meantime let's pin the version.